### PR TITLE
Jenkins: surface build failures to slack

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,6 +11,15 @@ def product = "ccd"
 def component = "case-activity-api"
 
 withPipeline(type, product, component) {
+    onMaster {
+        enableSlackNotifications('#ccd-master-builds')
+    }
+    onDemo {
+        enableSlackNotifications('#ccd-demo-builds')
+    }
+    onPR {
+        enableSlackNotifications('#ccd-pr-builds')
+    }
 
     afterCheckout {
         sh "yarn cache clean"

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -14,6 +14,7 @@ properties([
 ])
 
 withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.ENVIRONMENT, params.SUBSCRIPTION) {
+    enableSlackNotifications('#ccd-param-builds')
 
     afterCheckout {
         sh "yarn cache clean"


### PR DESCRIPTION
Ensure we have notifications for build failures, but break them out so that
relevant channels are used for master, demo, pr and sandbox* envs.




https://tools.hmcts.net/jira/browse/RDM-2947





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```