### PR TITLE
BEFTA PATCH: temporarily turn header checks to warning mode

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -56,6 +56,9 @@ env.OAUTH2_CLIENT_ID = "ccd_gateway"
 env.OAUTH2_REDIRECT_URI = "https://www-ccd.aat.platform.hmcts.net/oauth2redirect"
 env.DEFINITION_STORE_HOST = "http://ccd-definition-store-api-aat.service.core-compute-aat.internal"
 
+// Temporary workaround for platform changes: turn BEFTA header checks to warning mode
+env.BEFTA_RESPONSE_HEADER_CHECK_POLICY="JUST_WARN"
+
 withPipeline(type, product, component) {
     onMaster {
         enableSlackNotifications('#ccd-master-builds')


### PR DESCRIPTION
### JIRA link (if applicable) ###

To remove block on [RDM-8304](https://tools.hmcts.net/jira/browse/RDM-8304)


### Change description ###

Temporary workaround for platform changes: turn BEFTA header checks to warning mode

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
