### PR TITLE
RDM-8692: Increase UV_THREADPOOL_SIZE to 64

### DIFF
--- a/charts/ccd-case-activity-api/Chart.yaml
+++ b/charts/ccd-case-activity-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Helm chart for the HMCTS CCD Case Activity
 name: ccd-case-activity-api
 home: https://github.com/hmcts/ccd-case-activity-api
-version: 1.1.7
+version: 1.1.8
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-case-activity-api/values.yaml
+++ b/charts/ccd-case-activity-api/values.yaml
@@ -30,6 +30,7 @@ nodejs:
     REDIS_USER_DETAILS_TTL: 6000
     APP_REQUEST_TIMEOUT: 5
     APP_STORE_CLEANUP_CRONTAB: '* * * * *'
+    UV_THREADPOOL_SIZE: 64
 
   keyVaults:
     ccd:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-8692


### Change description ###

The UV threadpool is used by Node to allow synchronous tasks to be
performed asynchronously and not block the main node thread.

Tasks performed by this threadpool include, but are not limited to, DNS
resolution - see https://nodejs.org/api/cli.html#cli_uv_threadpool_size_size

This threadpool can become a bottleneck if eg. DNS requests are slow or
timeout, leading to requests queueing as they wait for an available
worker thread.

Increasing the size of this threadpool is desirable for the traffic
profile of api gateway, which typically handles a large number of
concurrent IO bound requests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
