### PR TITLE
CCD-1245: Updated CCD definitions to 7.0.0

### DIFF
--- a/aat/build.gradle
+++ b/aat/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '6.14.2'
+    testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0'
 }
 // end::dependencies[]
 

--- a/aat/src/java/uk/gov/hmcts/ccd/caseactivity/befta/CaseActivityTestAutomationAdapter.java
+++ b/aat/src/java/uk/gov/hmcts/ccd/caseactivity/befta/CaseActivityTestAutomationAdapter.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ccd.caseactivity.befta;
 
+import uk.gov.hmcts.befta.BeftaMain;
 import uk.gov.hmcts.befta.BeftaTestDataLoader;
 import uk.gov.hmcts.befta.DefaultBeftaTestDataLoader;
 import uk.gov.hmcts.befta.DefaultTestAutomationAdapter;
@@ -7,7 +8,8 @@ import uk.gov.hmcts.befta.dse.ccd.TestDataLoaderToDefinitionStore;
 
 public class CaseActivityTestAutomationAdapter extends DefaultTestAutomationAdapter {
 
-    private TestDataLoaderToDefinitionStore loader = new TestDataLoaderToDefinitionStore(this);
+    private TestDataLoaderToDefinitionStore loader = new TestDataLoaderToDefinitionStore(this,
+            "uk/gov/hmcts/ccd/test_definitions/valid", BeftaMain.getConfig().getDefinitionStoreUrl());
 
     @Override
     protected BeftaTestDataLoader buildTestDataLoader() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1245


### Change description ###
- Changed build.gradle to reference ccd-test-definitions version 7.0.0
instead of befta-fw version 6.14.2
- Changed setup of TestDataLoaderToDefinitionStore in
CaseActivityTestAutomationAdapter to use constructor that requires
definitions path and store URL to be explicitly specified.

These changes have been made following the splitting of CCD logic and
data from the BEFTA framework core - see CCD-1223.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
