### PR TITLE
Changed Jenkins library reference back to master branch

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -4,7 +4,7 @@ properties(
          pipelineTriggers([[$class: 'GitHubPushTrigger']])]
 )
 
-@Library("Infrastructure@CCD-1131")
+@Library("Infrastructure")
 
 def type = "nodejs"
 def product = "ccd"
@@ -13,7 +13,7 @@ def component = "case-activity-api"
 // Variables to switch pipeline logic and wiring per type of build
 def dataStoreDevelopPr       = "PR-1260" // This doesn't change frequently, but when it does, only change this value.
 def activityApiDevelopPr     = "PR-211"  // This doesn't change frequently, but when it does, only change this value.
-def prsToUseAat              = "PR-240,PR-280"  // Set this value to a PR number, or add it as a comma-separated value, if it's to follow CI/CD.
+def prsToUseAat              = "PR-282"  // Set this value to a PR number, or add it as a comma-separated value, if it's to follow CI/CD.
 
 def secrets = [
     'ccd-${env}': [

--- a/aat/build.gradle
+++ b/aat/build.gradle
@@ -21,7 +21,7 @@ repositories {
 // tag::dependencies[]
 dependencies {
     testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0'
-    testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.0.7.ccd-1131.5'
+    testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.0.7'
 }
 // end::dependencies[]
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-1283

### Change description ###

Jenkins library reference has been changed back to master branch from CCD-1131

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
