### PR TITLE
CCD-2293: Update hmcts/properties-volume dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@hmcts/nodejs-healthcheck": "1.7.0",
     "@hmcts/nodejs-logging": "^3.0.1",
-    "@hmcts/properties-volume": "^0.0.9",
+    "@hmcts/properties-volume": "^0.0.13",
     "applicationinsights": "^1.0.5",
     "body-parser": "^1.18.2",
     "config": "^1.26.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,10 +166,10 @@
     on-finished "^2.3.0"
     winston "^2.4.1"
 
-"@hmcts/properties-volume@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@hmcts/properties-volume/-/properties-volume-0.0.9.tgz#1c2b29a563fcad9041231442476a4a3b7a8abf7d"
-  integrity sha512-qW6XDDnJT8wPfSrrFNFkoQXbtWS/KE55ifeRzXeHAXB8CB9r8e8H33jCql/3WYz/LX6PGQRlrZrU27mtQaNQ4g==
+"@hmcts/properties-volume@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@hmcts/properties-volume/-/properties-volume-0.0.13.tgz#d1baeab407d519505aeb2614fb91632a1a328366"
+  integrity sha512-WTz5KTQG3IXQnNZCb63fR44muNn++GxGWZad0k12iIYsNfgws+dMOw7QwhbuKOMhQ2sSWxNK882ZxchVihZN9w==
   dependencies:
     "@hmcts/nodejs-logging" "^3.0.0"
     lodash "^4.17.11"


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2293 (https://tools.hmcts.net/jira/browse/CCD-2293)


### Change description ###
- Updated package.json.  Changed version of hmcts/properties-volume dependency to ^0.0.13.
- Regenerated yarn.lock file.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
