### PR TITLE
Fortify Issue 24644133

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # ---- Base Image ----
-ARG base=hmctspublic.azurecr.io/base/node:14-alpine
-
-FROM ${base} as base
+FROM hmctspublic.azurecr.io/base/node:14-alpine as base
 
 USER hmcts
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3206
Retrieving build dependencies using a non-specific version can leave the build system vulnerable to malicious binaries or cause the system to experience unexpected behavior.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
