### PR TITLE
CCD-3539 : Stop running Nightly builds on weekends

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,7 +2,8 @@
 
 properties([
     // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-    pipelineTriggers([cron('H 05 * * *')])
+    //CCD-3539 (Stop running Nightly builds on weekends). Original schedule was 'H 05 * * *'
+    pipelineTriggers([cron('H 05 * * 1-5')])
 ])
 
 @Library("Infrastructure")


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3539

### Change description ###

CCD-3539 : Stop running Nightly builds on weekends

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
