### PR TITLE
Onboard CVE dashboard intake

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -5,7 +5,7 @@ properties(
          pipelineTriggers([[$class: 'GitHubPushTrigger']])]
 )
 
-@Library("Infrastructure")
+@Library("Infrastructure@cve-dashboard")
 
 def type = "nodejs"
 def product = "ccd"
@@ -73,6 +73,7 @@ env.BEFTA_RESPONSE_HEADER_CHECK_POLICY = "JUST_WARN" // Temporary workaround for
 env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 withPipeline(type, product, component) {
+    enableCveDashboardIngestion()
     onMaster {
         enableSlackNotifications('#ccd-master-builds')
     }


### PR DESCRIPTION
## Summary
- use the CVE dashboard Jenkins library branch
- enable CVE dashboard ingestion for the CNP pipeline

## Testing
- Not run; Jenkins pipeline configuration only